### PR TITLE
Workaround for 'Unknown scanner'

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -247,7 +247,18 @@ class Model {
     setFilters(scanner, options.filters, options.filtersOptions)
 
     while (count < limit && tmp) {
-      tmp = await scanner.nextAsync()
+      try {
+        tmp = await scanner.nextAsync()
+      } catch (e) {
+        // Workaround for 'org.apache.hadoop.hbase.UnknownScannerException: Unknown scanner'.
+        // https://github.com/falsecz/hbase-rpc-client/blob/7293c97d6cbf6c7fa7d8655e5d7ea78759135d05/src/scan.coffee#L84
+        if ((e.stackTrace || '').includes('Unknown scanner')) {
+          tmp = null
+        } else {
+          throw e
+        }
+      }
+
       if (tmp && tmp.row) {
         results.push(tmp)
         count++


### PR DESCRIPTION
`Scanner.next()` 会沿用之前的 Scanner ID 获取下一个数据，但在完成请求后 (没有更多数据) 该 ID 会失效 (应该是被 hbase 自动回收了) ，从而出现以下问题：

```
org.apache.hadoop.hbase.UnknownScannerException: Unknown scanner '123'. This can happen due to any of the following reasons: a) Scanner id given is wrong, b) Scanner lease expired because of long wait between consecutive client checkins, c) Server may be closing down, d) RegionServer restart during upgrade.
If the issue is due to reason (b), a possible fix would be increasing the value of 'hbase.client.scanner.timeout.period' configuration.
```

经检查确认请求时间并未超过 b 的 timeout 值，也不是 c、d 的问题，更换不同的 docker image 也同样存在此问题，而且 REST API 和 shell 的 scanner 并不会有类似错误，scan 返回的结果也是正确的，所以暂时加一个 workaround，日后用 `hbase-rest` 替换或者从 rpc client 入手解决这个问题再把 workaround 去掉。

此问题在 `put()` 等方法时也会出现，原因是 `hbase-rpc-client` 会尝试用 `prefetch-TABLE` 的形式来检查缓存 region，而检查的方法中是用了 `scan.next()`，但官方也是[忽略这个错误](https://github.com/falsecz/hbase-rpc-client/blob/ea109923464d73528bf627d5fbe04bcd22ec50b7/src/client.coffee#L656)的，所以暂且这么处理。